### PR TITLE
Use the International System of Units for data sizes (decimal bytes)

### DIFF
--- a/addon/pages/directory.html
+++ b/addon/pages/directory.html
@@ -11,12 +11,12 @@
     const archive = new DatArchive(document.location);
     const path = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`;
 
-    const levels = ['bytes', 'kb', 'mb', 'gb']
+    const levels = ['bytes', 'kB', 'MB', 'GB', 'TB']
     function getSize(unit, level = 0) {
-      if (unit < 1024 || level === levels.length - 1) {
-        return `${unit}${levels[level]}`;
+      if (unit < 1000 || level === levels.length - 1) {
+        return `${unit} ${levels[level]}`;
       } else {
-        const next = Math.round(unit / 1024);
+        const next = Math.round(unit / 1000);
         return getSize(next, level + 1);
       }
     }

--- a/addon/pages/popup.js
+++ b/addon/pages/popup.js
@@ -5,11 +5,11 @@ async function getTab() {
   return tabs[0];
 }
 
-const units = ['bytes', 'kb', 'mb', 'gb'];
+const units = ['bytes', 'kB', 'MB', 'GB', 'TB'];
 
 function getSize(size, unit = 0) {
-  if (size > 1024 && unit < units.length - 1) {
-    return getSize(size / 1024, unit + 1);
+  if (size > 1000 && unit < units.length - 1) {
+    return getSize(size / 1000, unit + 1);
   }
   return `${Math.round(size * 10) / 10} ${units[unit]}`;
 }


### PR DESCRIPTION
* Switched to SI decimal byte sizes (the default everywhere except Windows).
* Add support for displaying sizes in Terabytes.
* Add a missing space.