### PR TITLE
Implement versioned URLs

### DIFF
--- a/background/dat.ts
+++ b/background/dat.ts
@@ -26,11 +26,14 @@ export interface Hyperdrive {
   writable: boolean
   content: Hypercore
   metadata: Hypercore
+  checkout(version: number): Hyperdrive
 }
 
 export interface DatArchive {
   url: string
   _dataStructure: Hyperdrive
+  _checkout: Hyperdrive
+  _version: number
   getInfo(opts?): Promise<any>
   stat(filepath: string, opts?): Promise<any>
   readdir(path: string, opts?)

--- a/background/protocol.ts
+++ b/background/protocol.ts
@@ -139,6 +139,12 @@ class DatHandler {
         path: lastPath,
       }
     }
+    if (await tryStat(joinPaths(root, `${path}.html`))) {
+      return {
+        archive,
+        path: lastPath,
+      }
+    }
     // for directories try to find an index file
     if (f && f.isDirectory()) {
       if (await tryStat(joinPaths(root, path, 'index.html'))) {
@@ -155,12 +161,6 @@ class DatHandler {
       }
       // error list directory
       throw new Error(ERROR.DIRECTORY);
-    }
-    if (await tryStat(joinPaths(root, `${path}.html`))) {
-      return {
-        archive,
-        path: lastPath,
-      }
     }
 
     if (manifest.fallback_page) {

--- a/background/types.d.ts
+++ b/background/types.d.ts
@@ -6,7 +6,16 @@ declare namespace browser.processScript {
 
 declare namespace browser.test {
   interface Assert {
-    ok(v: boolean): void
+    fail(message?: string): void
+    ok(v: boolean, message?: string): void
+    equal(actual: any, expected: any, message?: string): void
+    notEqual(actual: any, expected: any, message?: string): void
+    deepEqual(actual: any, expected: any, message?: string): void
+    notDeepEqual(actual: any, expected: any, message?: string): void
+    deepLooseEqual(actual: any, expected: any, message?: string): void
+    notDeepLooseEqual(actual: any, expected: any, message?: string): void
+    throws(fn: Function, expected: RegExp|Function, message?: string): void
+    doesNotThrow(fn: Function, message?: string): void
   }
   function test(name: string, test: (assert: Assert) => Promise<void>): void
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build:test": "webextify -r fs:graceful-fs -e test/test.ts -p tsify > test/test-bundle.js",
-    "test": "tape-ext ./test/manifest.json",
+    "test": "npm run build:test && tape-ext ./test/manifest.json",
     "build": "npm run build:background && npm run build:webapi",
     "build:background": "webextify -r fs:graceful-fs -e background/index.ts -p tsify > addon/background.js",
     "build:webapi": "browserify -e ./web-api/web-api.js > addon/web-api.js",

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,6 @@
+import * as parseUrl from 'parse-dat-url';
 import DatLibrary from '../background/library';
+import DatHandler from '../background/protocol';
 
 const { test } = browser.test;
 
@@ -22,4 +24,26 @@ test('Dat Network', async (assert) => {
   console.log(archive);
   assert.ok(!(await archive.getInfo()).isOwner);
   assert.ok((await archive.readdir('/')).includes('index.html'));
+});
+
+test('Protocol handler', async (assert) => {
+  const library = await setupLibrary();
+  const handler = new DatHandler(library.getArchiveFromUrl.bind(library));
+
+  const resolveUrl = async (url: string) => {
+    const { pathname, version } = parseUrl(url);
+    const { path } = await handler.resolvePath('dat://sammacbeth.eu+26/', pathname, parseInt(version));
+    return path;
+  }
+
+  let testDatAddress = '70fa7fd2670f48226fa3877e4d0b23d1a9124b086efe8831c5f8d6450aadc47c'
+  assert.equal(await resolveUrl(`dat://${testDatAddress}+28/`), '/index.html');
+  assert.equal(await resolveUrl(`dat://${testDatAddress}+28/posts`), '/posts/index.html');
+  assert.equal(await resolveUrl(`dat://${testDatAddress}+27/posts`), '/posts.html');
+  try {
+    await resolveUrl(`dat://${testDatAddress}+28/posts.html`)
+    assert.fail('Expected NOT_FOUND error');
+  } catch (e) {
+    assert.equal(e.message, 'NOT_FOUND');
+  }
 });


### PR DESCRIPTION
Enables versioned urls to be loaded with `+N` on the end of the hostname, e.g. `dat://sammacbeth.eu:27`.

Also fixes cases where resolution of urls was not consistent with beaker. Seems to also fix #12 