### PR TITLE
Add performance probe

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -17,7 +17,8 @@
         "unlimitedStorage",
         "tabs",
         "<all_urls>",
-        "dns"
+        "dns",
+        "alarms"
     ],
     "experiment_apis": {
         "protocol": {
@@ -110,6 +111,14 @@
                     ]
                 ],
                 "script": "libdweb/toolkit/components/extensions/child/ext-udp.js"
+            }
+        },
+        "performance": {
+            "schema": "performance/schema.json",
+            "child": {
+                "scopes": ["addon_child"],
+                "paths":[["performance"]],
+                "script": "performance/performance.js"
             }
         }
     },

--- a/addon/performance/performance.js
+++ b/addon/performance/performance.js
@@ -1,0 +1,12 @@
+
+this.performance = class extends ExtensionAPI {
+  getAPI(context) {
+    return {
+      performance: {
+        requestPerformanceMetrics: () => {
+          return ChromeUtils.requestPerformanceMetrics();
+        }
+      }
+    }
+  }
+};

--- a/addon/performance/schema.json
+++ b/addon/performance/schema.json
@@ -1,0 +1,14 @@
+[
+  {
+    "namespace": "performance",
+    "functions": [
+      {
+        "name": "requestPerformanceMetrics",
+        "type": "function",
+        "description": "",
+        "async": true,
+        "parameters": []
+      }
+    ]
+  }
+]

--- a/background/experiment.ts
+++ b/background/experiment.ts
@@ -1,5 +1,6 @@
 import createDatArchive from "@sammacbeth/dat-archive";
 import { DatAPI } from "./dat";
+import { IHyperdrive } from "@sammacbeth/dat-types/lib/hyperdrive";
 
 const publicTestDat = "ee172d7cd9235b2cf86ea9481e8a40e48cea29c743036621edc79a4765aa0281";    
 
@@ -33,6 +34,7 @@ export default class PerformanceExperiment {
         if (!perfLastDay || day !== perfLastDay) {
           this.run().then((result: any) => {
             result.hour = hour;
+            result.version = browser.runtime.getManifest().version;
             console.log('self-test results', result);
             sendAnolysisMessage(result, 'metrics.dat.performance');
             browser.storage.local.set({
@@ -59,7 +61,6 @@ export default class PerformanceExperiment {
     // test loading a dat
     const result: any = await this.runDatTest(publicTestDat, true, 30000);
     const { memory: activeMemory, totalDispatches: activeDispatches } = await this.probePerformance();
-
 
     return {
       duration,
@@ -94,8 +95,10 @@ export default class PerformanceExperiment {
           } catch (e) {}
         }
         if (result.dat) {
-          result.finalVersion = result.dat.drive.version;
+          const drive: IHyperdrive = result.dat.drive;
+          result.finalVersion = drive.version;
         }
+        
         resolve(result);
       }, timeout);
     });
@@ -105,7 +108,7 @@ export default class PerformanceExperiment {
     const start = Date.now();
     const dat = await this.node.getDat(address, {
       persist,
-      sparse: true
+      sparse: true,
     });
     yield {
       loaded: Date.now() - start,

--- a/background/experiment.ts
+++ b/background/experiment.ts
@@ -1,0 +1,148 @@
+import createDatArchive from "@sammacbeth/dat-archive";
+import { DatAPI } from "./dat";
+
+const publicTestDat = "ee172d7cd9235b2cf86ea9481e8a40e48cea29c743036621edc79a4765aa0281";    
+
+function sendAnolysisMessage(message, schema) {
+  browser.runtime.sendMessage('cliqz@cliqz.com', {
+    moduleName: 'core',
+    action: 'sendTelemetry',
+    args: [message, false, schema],
+  })
+}
+
+export default class PerformanceExperiment {
+  constructor(protected node: DatAPI) {}
+
+  start() {
+    // setup timer to start on next hour
+    const alarmName = "experiment timer";
+    const when = new Date();
+    when.setMinutes(0);
+    when.setSeconds(0);
+    when.setHours(when.getHours() + 1);
+    browser.alarms.create(alarmName, {
+      when: when.valueOf(),
+      periodInMinutes: 60,
+    });
+    browser.alarms.onAlarm.addListener(async alarm => {
+      if (alarm.name === alarmName) {
+        const t = new Date();
+        const [day, hour] = [t.getDate(), t.getHours()];
+        const { perfLastDay } = await browser.storage.local.get(['perfLastDay']);
+        if (!perfLastDay || day !== perfLastDay) {
+          this.run().then((result: any) => {
+            result.hour = hour;
+            console.log('self-test results', result);
+            sendAnolysisMessage(result, 'metrics.dat.performance');
+            browser.storage.local.set({
+              perfLastDay: day,
+            });
+          });
+        }
+      }
+    });
+  }
+
+  async run() {
+    // idle performance
+    const {
+      duration,
+      memory: idleMemory,
+      totalDispatches
+    } = await this.probePerformance();
+    // wait 30s
+    await new Promise((resolve) => setTimeout(resolve, 30000));
+    // check dispatches during the 30s idle wait
+    const { totalDispatches: dispatchesAfterIdle } = await this.probePerformance();
+    
+    // test loading a dat
+    const result: any = await this.runDatTest(publicTestDat, true, 30000);
+    const { memory: activeMemory, totalDispatches: activeDispatches } = await this.probePerformance();
+
+
+    return {
+      duration,
+      idleMemory,
+      idleDispatches: dispatchesAfterIdle - totalDispatches,
+      activeMemory,
+      activeDispatches: activeDispatches - dispatchesAfterIdle,
+      tLoaded: result.loaded,
+      tReady: result.ready,
+      tInfo: result.info,
+      loadedVersion: result.version,
+      finalVersion: result.finalVersion,
+      initialPeers: result.initialPeers,
+      finalPeers: result.finalPeers,
+    }
+  }
+
+  async runDatTest(address: string, persist: boolean, timeout: number) {
+    let result: any = {};
+    (async () => {
+      const resultIt = this.datTest(address, persist);
+      for await (const info of resultIt) {
+        Object.assign(result, info);
+      }
+      Promise.resolve({});
+    })();
+    return new Promise((resolve) => {
+      setTimeout(async () => {
+        if (result.archive) {
+          try {
+            result.finalPeers = (await result.archive.getInfo()).peers;
+          } catch (e) {}
+        }
+        if (result.dat) {
+          result.finalVersion = result.dat.drive.version;
+        }
+        resolve(result);
+      }, timeout);
+    });
+  }
+
+  async *datTest(address: string, persist: boolean) {
+    const start = Date.now();
+    const dat = await this.node.getDat(address, {
+      persist,
+      sparse: true
+    });
+    yield {
+      loaded: Date.now() - start,
+      dat,
+    };
+    await dat.ready;
+    yield {
+      ready: Date.now() - start,
+      version: dat.drive.version
+    };
+    const archive = createDatArchive(dat.drive);
+    const { peers } = await archive.getInfo();
+    yield {
+      info: Date.now() - start,
+      initialPeers: peers,
+      archive,
+    };
+    return;
+  }
+
+  async probePerformance() {
+    const extensionHost = new URL(browser.runtime.getURL("")).hostname;
+    const metrics = await browser.performance.requestPerformanceMetrics();
+    const extensionMetrics = metrics.find(m => m.host === extensionHost);
+    if (extensionMetrics) {
+      return {
+        duration: extensionMetrics.duration,
+        memory: extensionMetrics.memoryInfo.GCHeapUsage,
+        totalDispatches: extensionMetrics.items.reduce((acc, val) => {
+          return acc + val.count;
+        }, 0)
+      };
+    }
+    return {
+      duration: 0,
+      memory: 0,
+      totalDispatches: 0
+    };
+  }
+}

--- a/background/index.ts
+++ b/background/index.ts
@@ -4,6 +4,7 @@ import DatApi from './api';
 import DatDb from './db';
 import nodeFactory from './dat';
 import DatDNS from './dns';
+import Experiment from './experiment';
 
 const node = nodeFactory();
 const db = new DatDb();
@@ -81,3 +82,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     browser.pageAction.hide(tabId);
   }
 });
+
+const experiment = new Experiment(node);
+experiment.start();
+(<any>window).experiment = experiment;

--- a/background/types.d.ts
+++ b/background/types.d.ts
@@ -27,3 +27,34 @@ declare namespace browser.protocol {
   }
   function registerProtocol(name: string, handler: (request: Request) => Response): void
 }
+
+declare namespace browser.performance {
+  type MediaMemoryInfo = {
+    audioSize: number
+    videoSize: number
+    resourcesSize: number
+  }
+  type MemoryInfo = {
+    domDom: number
+    domStyle: number
+    domOther: number
+    GCHeapUsage: number
+    media: MediaMemoryInfo
+  }
+  type CategoryDispatch = {
+    category: number
+    count: number
+  }
+  type PerformanceInfo = {
+    host: string
+    pid: number
+    windowId: number
+    duration: number
+    counterId: number
+    isWorker: boolean
+    isTopLevel: boolean
+    memoryInfo: MemoryInfo
+    items: CategoryDispatch[]
+  }
+  function requestPerformanceMetrics(): PerformanceInfo[]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-      "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+      "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -60,9 +60,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-      "integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.6.tgz",
+      "integrity": "sha512-QYp/8xdH8iMin3pH5gtT/rUuttVfIcOhWBC3wh9Eh/qs4jEe39+3DpCDLgWXhMQgiCTOH8mrLSvQ0OHOCcox9g==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -138,9 +138,9 @@
       }
     },
     "@sammacbeth/dat-api-v1wrtc": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@sammacbeth/dat-api-v1wrtc/-/dat-api-v1wrtc-0.0.8.tgz",
-      "integrity": "sha512-zCkhtcr4uWouRfpv3LGjdcMRXDWJ51jT5P3bvb9QWXPxq9nZaDJY/XQYX06TKiGNQiPa6/tZ1piVt2xefOPUCg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@sammacbeth/dat-api-v1wrtc/-/dat-api-v1wrtc-0.1.1.tgz",
+      "integrity": "sha512-Q636OfspsJQ9L1Z9PWjZTPJviSZcyVu9QnfHvO7eVx3QqLfAf6T6B+t5SwaoKVSK22rJjdEnprhfmW9I34AUaA==",
       "requires": {
         "@sammacbeth/dat-api-core": "^0.1.0",
         "@sammacbeth/dat-network-hyperdiscovery": "^0.0.7",
@@ -229,9 +229,9 @@
       }
     },
     "@sammacbeth/dat-protocol-handler": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@sammacbeth/dat-protocol-handler/-/dat-protocol-handler-0.0.8.tgz",
-      "integrity": "sha512-JOCOnrQpb20Ctv/uhrblZ07n3ni3y6lM91itaV+MClrKATFKBPYW7kUEdIiDOF27Be3W44hI9fIe6X7g+OXstw==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@sammacbeth/dat-protocol-handler/-/dat-protocol-handler-0.0.9.tgz",
+      "integrity": "sha512-aGn8U6dS75FORUV5EKbegnQUhiFx1UlMBi0xKm+6M5HrbuEz0iscNCOsPXNPGhjR7KCd/hJlYe98LsihSZAPyQ==",
       "requires": {
         "@sammacbeth/dat-api-core": "^0.1.0",
         "@sammacbeth/dat-types": "^0.1.0",
@@ -333,9 +333,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-      "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
+      "version": "12.12.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.16.tgz",
+      "integrity": "sha512-vRuMyoOr5yfNf8QWxXegOjeyjpWJxFePzHzmBOIzDIzo+rSqF94RW0PkS6y4T2+VjAWLXHWrfbIJY3E3aS7lUw=="
     },
     "JSONSelect": {
       "version": "0.2.1",
@@ -2937,9 +2937,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -8084,9 +8084,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
-      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
       "dev": true
     },
     "public-encrypt": {
@@ -9274,15 +9274,15 @@
       }
     },
     "simple-signal-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/simple-signal-client/-/simple-signal-client-2.3.0.tgz",
-      "integrity": "sha512-A4oXLm7jK1E8byZhuRvdZJwqCA/tsLDFI2agNzQPbS/RT0LULlZNdAu3GH3GPolOnfaFtt5cEldc7vNGngTWDg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/simple-signal-client/-/simple-signal-client-2.3.1.tgz",
+      "integrity": "sha512-G1w2Ya4+scKah6mXkU6EZogo896uobgcnnWqgqYN1vJsF6o5IAjj9ZNSuoj82F9CNPSPKazie3Wmv+0eNYkVGQ==",
       "requires": {
         "babel-polyfill": "^6.23.0",
         "cuid": "^2.0.2",
         "inherits": "^2.0.3",
         "nanobus": "^4.3.3",
-        "simple-peer": "^9.2.0"
+        "simple-peer": "^9.6.2"
       }
     },
     "simple-signal-server": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "license": "MIT",
   "dependencies": {
     "@cliqz-oss/dexie": "^2.0.4",
-    "@sammacbeth/dat-api-v1wrtc": "^0.0.8",
+    "@sammacbeth/dat-api-v1wrtc": "^0.1.1",
     "@sammacbeth/dat-archive": "^0.0.10",
     "@sammacbeth/dat-node": "1.0.3",
-    "@sammacbeth/dat-protocol-handler": "^0.0.8",
+    "@sammacbeth/dat-protocol-handler": "^0.0.9",
     "@sammacbeth/dat-types": "^0.1.0",
     "@sammacbeth/libdweb": "0.0.8",
     "@sammacbeth/utp-wasm": "^1.1.5",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -15,3 +15,5 @@ sed -i.bak "s/require('process-nextick-args')/process.nextTick/g" ./node_modules
 sed -i.bak "s/require('utp-native')/require('\@sammacbeth\/utp-wasm')/g" ./node_modules/discovery-swarm/index.js && rm ./node_modules/discovery-swarm/index.js.bak
 # Require path.posix in hyperdrive
 sed -i.bak "s/require('path').posix/require('path')/g" ./node_modules/hyperdrive/index.js && rm ./node_modules/hyperdrive/index.js.bak
+# Reduce dns cache clean interval
+sed -i.bak "s/options.interval/300/g" ./node_modules/dat-dns/cache.js && rm ./node_modules/dat-dns/cache.js.bak


### PR DESCRIPTION
Runs a self-test once per day, checking connectivity to dat peers and
performance cost of dat.

The aim is to measure how many users are able to load a specific dat, and how quickly. Activation of the test is synchronized to the beginning of a new hour, so we can also test a potential large number of peers in the swarm.